### PR TITLE
Add 'datannur' to open source metadata catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ This awesome list is a part of Dateno project and is derived from registry of da
 ### Metadata catalogs
 
 #### Open source
+* [datannur](https://datannur.com) - Open source, lightweight and portable data catalog that runs entirely from a static folder, no server required. Scans files and databases and exports DCAT-AP, GeoDCAT-AP and STAC.
 * [Fusion Metadata Registry](https://www.sdmx.io/fmr/) - open source metadata catalog used by European Union authorities and some countries statistical agencies. Open source by request
 
 ## Standards                   


### PR DESCRIPTION
Hi, I'm the author of datannur, suggesting it for the Metadata catalogs section.

datannur is an open source data catalog developed in Switzerland, in production
in a cantonal statistical office. Its particularity: it runs entirely from a
static folder (even file://), no server or database required. A Python builder
scans files and databases, and the catalog exports DCAT-AP, GeoDCAT-AP, STAC
and ISO 19139.

- Website: https://datannur.com
- Source: https://github.com/datannur/datannur
- Live demo: https://dev.datannur.com

Thanks for maintaining this list!